### PR TITLE
Fixed bug were url was not valid

### DIFF
--- a/lucky.go
+++ b/lucky.go
@@ -66,10 +66,18 @@ func main() {
 						if attr.Key == "href" {
 
 							if strings.Contains(attr.Val, urlPrefix) {
-								results += 1
+								// exclude '/url?q=' from final url
 								url := strings.Replace(attr.Val, urlPrefix, "", 1)
-								fmt.Printf("%d) %s\n", results, url)
-								browser.OpenURL(url)
+								// exclude & and everything after it, unneeded for destination url
+								if endIndex := strings.Index(url, "&"); endIndex > 0 {
+									url = url[:endIndex]
+								}
+								// only use this url if it doesn't have 'google' in it
+								if !strings.Contains(url, "google") {
+									results++
+									fmt.Printf("%d) %s\n", results, url)
+									browser.OpenURL(url)
+								}
 							}
 
 							break


### PR DESCRIPTION
Google adds some extra characters to the url in each anchor's
href. In this change we remove the superflous characters and also
excule all urls that have the substring 'google' in them